### PR TITLE
fix(241): Orderstatus set to awaiting payment when transaction is expired or cancelled

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "homepage": "https://github.com/MonozNL/lunar-api-mollie-adapter",
   "license": "MIT",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "authors": [
     {
       "name": "Thomas van der Westen",


### PR DESCRIPTION
This pull request removes the functionality that automatically set an order’s status to awaiting_payment whenever its associated transaction was marked expired or cancelled. Since order status transitions ar handled by the main project (monoz-api), having this in-package logic is both redundant and a source of conflicting state updates.